### PR TITLE
Use sqlite .coverage file to do cool stuff

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,10 +43,12 @@ Run ``flycheck-select-checker``, pick ``python-coverage``.
 Coverage data
 =============
 
-This package reads the XML output produced by Python's ``coverage``
-package. Usually this file is named ``coverage.xml``.
+This package can read both the SQLite ``.coverage`` file created by Python’s
+``coverage`` package, and the XML report it produces. The latter is preferred if
+present, because the ``coverage xml`` command does some additional analysis to
+ignore docstrings etc.
 
-With plain `coverage`:
+With plain ``coverage``, generate the XML file like this:
 
 .. code-block:: shell
 
@@ -61,7 +63,7 @@ With ``pytest-cov``, pass ``--cov-report=xml``, e.g. via ``pyproject.toml``:
     "--cov=your-package",
     "--cov=test",
     "--cov-report=xml",
-  ]
+
 
 Customization
 =============
@@ -73,7 +75,8 @@ Command for manual coverage file selection:
 Customizable settings (see their description for details) in the
 ``python-coverage`` group, e.g. via ``M-x customize-group``:
 
-- ``python-coverage-default-file-name``
+- ``python-coverage-default-xml-file-name``
+- ``python-coverage-default-sqlite-file-name``
 - ``python-coverage-overlay-width``
 
 Styling via custom faces, e.g. via ``M-x customize-face``:


### PR DESCRIPTION
This is a PR that combines a lot of stuff (mentioned in #6), so I'm not expecting it to be merged as is, but I thought I'd share at this point even if it's not quite ready. I have been using this for several months now and found it useful.

Also my elisp is probably pretty bad!

Basically 2 main features:

1. The ability to use the `.coverage` SQLite file directly, without needing the `coverage.xml` report to be generated, for normal overlay analysis. The SQLite file is less preferred, because the XML file contains processing done to handling empty lines and docstrings etc,. - analysis that could not easily be reproduced in elisp, it requires a Python parser. 

   This requires using some internals of the coverage SQLite schema, and reproducing some of the "packing" logic for line numbers (see https://github.com/nedbat/coveragepy/blob/master/coverage/numbits.py ). However, we include version checking of the file, and if the schema changes in the future, we can add support for multiple schemas easily.

3. If `--cov-context=test` has been used, it adds the ability to find which tests executed which lines of code. This can only be implemented using the SQLite file, as the XML doesn't contain this info. The only user interface on this at the moment is the command `python-coverage-rerun-pytest-current-region` command, which is the only interface I needed. It basically allows you to put your cursor somewhere in the code, do `M-x python-coverage-rerun-pytest-current-region` and get a pytest command line for rerunning the tests that executed that code, like this:
```shell
pytest path/to/tests.py::test_1 path/to/tests.py::test_2 
```

This is super useful on some occasions!
