### PR TITLE
Add support for gcovr reports for C/C++ languages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,9 @@ This is an experimental Emacs package to report code coverage output
 produced by Python's ``coverage`` package directly inside Emacs
 buffers.
 
+``coverage``'s xml output follows the cobertura format, it should work with
+similar reports from other tools, like C/C++ with ``gcovr``.
+
 Best used together with `python-pytest.el`__.
 
 __ https://github.com/wbolster/emacs-python-pytest


### PR DESCRIPTION
Hello,
First all thank you for your great package, it works well out of the box, is short and the code well written.

I work also with c++ file, for which coverage reports are frequently generated in cobertura format, generated with gcovr.

Since the xml format is the same, I assumed it should work as well.

I encountered two hurdles :
1) gcovr uses a relative source directory where your work expects an absolute path
2) gcovr does not use the filename as the "class" attribute, you have to use the "filename" attribute instead

1 : handled by passing the coverage file path down to the python-coverage--class-node-matches-file-name? function.
it is then used to expand the relative path into an absolute path.

It still works with python's relative source dir path from what I've tested.

2 : I removed your prefilter based on the "class"  name.
I rely directly on your python-coverage--class-node-matches-file-name?  function for match detection

I have tested these changes on toys projects for python / c++, I will try to use it everyday at work from now on.


