### PR TITLE
Handle long overlay properly

### DIFF
--- a/python-coverage.el
+++ b/python-coverage.el
@@ -350,9 +350,7 @@ If OUTDATED is non-nil, use a different style."
                (if python-coverage-overlay-width
                    (min
                     (line-end-position)
-                    (progn
-                      (forward-char python-coverage-overlay-width)
-                      (point)))
+                    (+ (point) python-coverage-overlay-width))
                  ;; End of statement for python
                  ;; fallback to end of line for other languages
                  (if (derived-mode-p 'python-mode 'python-ts-mode)

--- a/python-coverage.el
+++ b/python-coverage.el
@@ -353,8 +353,13 @@ If OUTDATED is non-nil, use a different style."
                     (progn
                       (forward-char python-coverage-overlay-width)
                       (point)))
-                 (python-nav-end-of-statement)
-                 (1+ (point)))))
+                 ;; End of statement for python
+                 ;; fallback to end of line for other languages
+                 (if (derived-mode-p 'python-mode 'python-ts-mode)
+                     (progn
+                       (python-nav-end-of-statement)
+                       (1+ (point)))
+                   (line-end-position)))))
             (end
              ;; At least one character. This should only happen for
              ;; outdated overlays on empty lines.


### PR DESCRIPTION
Hello,
Thank you for merging my MR a few weeks back adding support for other language like C++

I have been able to use your awesome package some more.
I have noticed two issues, one related to my previous MR, the other predates it.

### Non-python languages overlay broken when `python-coverage-overlay-width` is not set.
If it is not set, your plugin rely on `python-nav-end-of-statement` to highlight the whole statement. This function obviously does not work for c++ code.
This MR addresses this by checking if the current mode is derived from `python-mode` or `python-ts-mode`. If not, only highlight up to the end of line.

###  `python-coverage-overlay-width` does not work when too close to the end of file
 if `(point) + python-coverage-overlay-width` is bigger than `(point-max)`, it causes an error and the overlay is not displayed.
I address this here by computing the end position instead of navigating to it, since it was the navigation which triggered the issue.
Arguably this should not happen often if people set this value to 2 like you suggest, but with bigger values it did happen for me.

Feel free to ask for changes !
Thank you for your work

