### PR TITLE
Change xml+ version to 0

### DIFF
--- a/python-coverage.el
+++ b/python-coverage.el
@@ -2,7 +2,7 @@
 
 ;; Author: wouter bolsterlee <wouter@bolsterl.ee>
 ;; Version: 1.0.0
-;; Package-Requires: ((emacs "25.1") (dash "2.18.0") (s "1.12.0") (xml+ "1"))
+;; Package-Requires: ((emacs "25.1") (dash "2.18.0") (s "1.12.0") (xml+ "0"))
 ;; Keywords: languages, processes, tools
 ;; URL: https://github.com/wbolster/emacs-python-coverage
 


### PR DESCRIPTION
Weird bug but Elpaca doesn't seem to load the package because `xml+`'s version is `0.0.0` in the source file, so it rejects it because the version in the requirements is too high. Seems to work fine if I set it to `0`.